### PR TITLE
Add audit dashboard to web UI

### DIFF
--- a/src/main/java/eu/pankraz01/glra/Config.java
+++ b/src/main/java/eu/pankraz01/glra/Config.java
@@ -62,6 +62,22 @@ public class Config {
             .comment("Require a non-empty webApiToken for all web UI/API calls; if true and token is empty, the web UI is disabled")
             .define("requireApiToken", false);
 
+    public static final ModConfigSpec.BooleanValue WEB_AUDIT_ENABLED = BUILDER
+            .comment("Expose the audit dashboard in the web UI (default: true)")
+            .define("webAuditEnabled", true);
+
+    public static final ModConfigSpec.BooleanValue WEB_AUDIT_CHAT_ENABLED = BUILDER
+            .comment("Include chat history in the audit dashboard (default: true)")
+            .define("webAuditChatEnabled", true);
+
+    public static final ModConfigSpec.BooleanValue WEB_AUDIT_BLOCKS_ENABLED = BUILDER
+            .comment("Include block place/break history in the audit dashboard (default: true)")
+            .define("webAuditBlocksEnabled", true);
+
+    public static final ModConfigSpec.BooleanValue WEB_AUDIT_CONTAINERS_ENABLED = BUILDER
+            .comment("Include inventory/container history in the audit dashboard (default: true)")
+            .define("webAuditContainersEnabled", true);
+
     static {
         BUILDER.push("logUnauthorizedWebAccess");
     }

--- a/src/main/java/eu/pankraz01/glra/database/dao/AuditDAO.java
+++ b/src/main/java/eu/pankraz01/glra/database/dao/AuditDAO.java
@@ -1,0 +1,121 @@
+package eu.pankraz01.glra.database.dao;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+
+import eu.pankraz01.glra.database.DBConnection;
+
+/**
+ * Lightweight DAO to load recent audit data for the web dashboard.
+ */
+public final class AuditDAO {
+    public record ChatEntry(long ts, String playerName, String message) {}
+
+    public record BlockEntry(long ts, String playerName, String levelName, int x, int y, int z, String materialName,
+                             int actionCode) {}
+
+    public record ContainerEntry(long ts, String playerName, String levelName, int x, int y, int z, String materialName,
+                                 int amount, int actionCode) {}
+
+    public List<ChatEntry> loadRecentChat(int limit) throws SQLException {
+        List<ChatEntry> result = new ArrayList<>();
+        SQLException lastError = null;
+
+        // GriefLogger chat schemas are not officially documented; try a few sensible defaults.
+        List<String> candidates = List.of(
+                "SELECT c.time AS ts, u.name AS player_name, c.message AS msg FROM chat c LEFT JOIN users u ON u.id = c.user ORDER BY c.time DESC LIMIT ?",
+                "SELECT c.time AS ts, u.name AS player_name, c.msg AS msg FROM chat c LEFT JOIN users u ON u.id = c.user ORDER BY c.time DESC LIMIT ?",
+                "SELECT c.time AS ts, u.name AS player_name, c.message AS msg FROM chatlog c LEFT JOIN users u ON u.id = c.user ORDER BY c.time DESC LIMIT ?"
+        );
+
+        for (String sql : candidates) {
+            try (Connection conn = DBConnection.getConnection(); PreparedStatement ps = conn.prepareStatement(sql)) {
+                ps.setInt(1, Math.max(1, limit));
+                try (ResultSet rs = ps.executeQuery()) {
+                    while (rs.next()) {
+                        result.add(new ChatEntry(
+                                rs.getLong("ts"),
+                                rs.getString("player_name"),
+                                rs.getString("msg")
+                        ));
+                    }
+                }
+                // Succeeded with this statement; ignore later candidates.
+                return result;
+            } catch (SQLException e) {
+                lastError = e;
+                result.clear();
+            }
+        }
+
+        if (lastError != null) throw lastError;
+        return result;
+    }
+
+    public List<BlockEntry> loadRecentBlocks(int limit) throws SQLException {
+        List<BlockEntry> result = new ArrayList<>();
+        final StringBuilder sql = new StringBuilder();
+        sql.append("SELECT b.time AS ts, u.name AS player_name, l.name AS level_name, b.x, b.y, b.z, m.name AS material_name, b.action AS action_code ");
+        sql.append("FROM blocks b ");
+        sql.append("LEFT JOIN materials m ON m.id = b.type ");
+        sql.append("LEFT JOIN users u ON u.id = b.user ");
+        sql.append("LEFT JOIN levels l ON l.id = b.level ");
+        sql.append("ORDER BY b.time DESC LIMIT ?");
+
+        try (Connection conn = DBConnection.getConnection(); PreparedStatement ps = conn.prepareStatement(sql.toString())) {
+            ps.setInt(1, Math.max(1, limit));
+            try (ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    result.add(new BlockEntry(
+                            rs.getLong("ts"),
+                            rs.getString("player_name"),
+                            rs.getString("level_name"),
+                            rs.getInt("x"),
+                            rs.getInt("y"),
+                            rs.getInt("z"),
+                            rs.getString("material_name"),
+                            rs.getInt("action_code")
+                    ));
+                }
+            }
+        }
+
+        return result;
+    }
+
+    public List<ContainerEntry> loadRecentContainers(int limit) throws SQLException {
+        List<ContainerEntry> result = new ArrayList<>();
+        final StringBuilder sql = new StringBuilder();
+        sql.append("SELECT c.time AS ts, u.name AS player_name, l.name AS level_name, c.x, c.y, c.z, m.name AS material_name, c.amount AS amount, c.action AS action_code ");
+        sql.append("FROM containers c ");
+        sql.append("LEFT JOIN materials m ON m.id = c.type ");
+        sql.append("LEFT JOIN users u ON u.id = c.user ");
+        sql.append("LEFT JOIN levels l ON l.id = c.level ");
+        sql.append("ORDER BY c.time DESC LIMIT ?");
+
+        try (Connection conn = DBConnection.getConnection(); PreparedStatement ps = conn.prepareStatement(sql.toString())) {
+            ps.setInt(1, Math.max(1, limit));
+            try (ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    result.add(new ContainerEntry(
+                            rs.getLong("ts"),
+                            rs.getString("player_name"),
+                            rs.getString("level_name"),
+                            rs.getInt("x"),
+                            rs.getInt("y"),
+                            rs.getInt("z"),
+                            rs.getString("material_name"),
+                            rs.getInt("amount"),
+                            rs.getInt("action_code")
+                    ));
+                }
+            }
+        }
+
+        return result;
+    }
+}

--- a/src/main/resources/web/audit.html
+++ b/src/main/resources/web/audit.html
@@ -1,0 +1,240 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Audit</title>
+  <link rel="stylesheet" href="/web/rollback.css" />
+</head>
+<body class="page">
+  <div class="container">
+    <div class="header split">
+      <div>
+        <h1>Audit</h1>
+        <p id="subtitle">Live history from the database</p>
+      </div>
+      <div class="action-row">
+        <a class="button secondary" href="/">⟵ Rollback</a>
+        <button id="btn-refresh" type="button">Refresh now</button>
+      </div>
+    </div>
+
+    <div id="toast" class="toast" role="status" aria-live="polite"></div>
+
+    <div class="card">
+      <div class="settings-row">
+        <div class="field">
+          <label for="token-input">Token</label>
+          <input type="password" id="token-input" placeholder="Token" autocomplete="current-password" />
+        </div>
+        <div class="field">
+          <label for="limit-input">Max entries per tab</label>
+          <input type="number" id="limit-input" value="100" min="10" max="500" />
+        </div>
+      </div>
+      <div id="status" class="muted"></div>
+      <div class="tabs" role="tablist">
+        <button class="tab active" data-tab="chat" role="tab">Chat</button>
+        <button class="tab" data-tab="blocks" role="tab">Blocks</button>
+        <button class="tab" data-tab="containers" role="tab">Inventory</button>
+      </div>
+      <div id="panel-chat" class="tab-panel active" role="tabpanel"></div>
+      <div id="panel-blocks" class="tab-panel" role="tabpanel"></div>
+      <div id="panel-containers" class="tab-panel" role="tabpanel"></div>
+    </div>
+  </div>
+
+  <script>
+    const panels = {
+      chat: document.getElementById('panel-chat'),
+      blocks: document.getElementById('panel-blocks'),
+      containers: document.getElementById('panel-containers')
+    };
+    const tabs = document.querySelectorAll('.tab');
+    const toast = document.getElementById('toast');
+    const status = document.getElementById('status');
+    const tokenInput = document.getElementById('token-input');
+    const limitInput = document.getElementById('limit-input');
+    const refreshBtn = document.getElementById('btn-refresh');
+
+    let refreshHandle;
+
+    function savedToken() {
+      const fromInput = (tokenInput.value || '').trim();
+      if (fromInput) return fromInput;
+      const stored = localStorage.getItem('glraToken');
+      if (stored) return stored;
+      const viaUrl = new URLSearchParams(location.search).get('token');
+      return viaUrl || '';
+    }
+
+    function applySavedToken() {
+      const token = savedToken();
+      if (token && !tokenInput.value) tokenInput.value = token;
+    }
+
+    function showToast(text, variant = 'info') {
+      if (!text) return;
+      toast.textContent = text;
+      toast.className = `toast ${variant}`;
+      toast.setAttribute('aria-hidden', 'false');
+      clearTimeout(window.__toastTimeout);
+      window.__toastTimeout = setTimeout(() => hideToast(), 6000);
+    }
+
+    function hideToast() {
+      toast.setAttribute('aria-hidden', 'true');
+      toast.className = 'toast';
+    }
+
+    function switchTab(id) {
+      tabs.forEach(tab => tab.classList.toggle('active', tab.dataset.tab === id));
+      Object.entries(panels).forEach(([key, el]) => {
+        el.classList.toggle('active', key === id);
+      });
+    }
+
+    tabs.forEach(tab => tab.addEventListener('click', () => switchTab(tab.dataset.tab)));
+
+    function headers() {
+      const token = savedToken();
+      const h = { 'Accept': 'application/json' };
+      if (token) h['X-Auth-Token'] = token;
+      return h;
+    }
+
+    async function loadMeta() {
+      try {
+        const res = await fetch('/api/audit/meta');
+        if (!res.ok) return;
+        const data = await res.json();
+        if (!data.enabled) {
+          status.textContent = 'Audit dashboard is disabled in the config.';
+          stopAutoRefresh();
+          return false;
+        }
+        tabs.forEach(tab => {
+          const enabled = data[tab.dataset.tab];
+          tab.disabled = !enabled;
+          if (!enabled) {
+            panels[tab.dataset.tab].innerHTML = '<p class="muted">Disabled in config.</p>';
+          }
+        });
+        return true;
+      } catch (err) {
+        console.warn('Audit meta failed', err);
+        return false;
+      }
+    }
+
+    function renderChat(entries) {
+      if (!entries || entries.length === 0) return '<p class="muted">No chat messages found.</p>';
+      return '<ul class="audit-list">' + entries.map(e => {
+        const ts = new Date(e.ts).toLocaleString();
+        const player = e.player || 'Unknown';
+        const msg = e.message || '';
+        return `<li><div class="audit-title">${ts} · ${player}</div><div class="audit-body">${escapeHtml(msg)}</div></li>`;
+      }).join('') + '</ul>';
+    }
+
+    function renderBlocks(entries) {
+      if (!entries || entries.length === 0) return '<p class="muted">No block actions found.</p>';
+      return '<ul class="audit-list">' + entries.map(e => {
+        const ts = new Date(e.ts).toLocaleString();
+        const player = e.player || 'Unknown';
+        const action = blockActionLabel(e.action);
+        const material = e.material || 'unknown';
+        const loc = `${e.level || ''} @ ${e.x},${e.y},${e.z}`;
+        return `<li><div class="audit-title">${ts} · ${player}</div><div class="audit-body">${action} ${material} — ${loc}</div></li>`;
+      }).join('') + '</ul>';
+    }
+
+    function renderContainers(entries) {
+      if (!entries || entries.length === 0) return '<p class="muted">No inventory actions found.</p>';
+      return '<ul class="audit-list">' + entries.map(e => {
+        const ts = new Date(e.ts).toLocaleString();
+        const player = e.player || 'Unknown';
+        const action = containerActionLabel(e.action);
+        const material = e.material || 'unknown';
+        const loc = `${e.level || ''} @ ${e.x},${e.y},${e.z}`;
+        return `<li><div class="audit-title">${ts} · ${player}</div><div class="audit-body">${action} ${e.amount || 0}x ${material} — ${loc}</div></li>`;
+      }).join('') + '</ul>';
+    }
+
+    function blockActionLabel(code) {
+      switch (code) {
+        case 0: return 'Break';
+        case 1: return 'Place';
+        default: return 'Change';
+      }
+    }
+
+    function containerActionLabel(code) {
+      switch (code) {
+        case 1: return 'Add to container';
+        case 0: return 'Remove from container';
+        default: return 'Change container';
+      }
+    }
+
+    function escapeHtml(text) {
+      const map = {"&":"&amp;","<":"&lt;",">":"&gt;","\"":"&quot;","'":"&#39;"};
+      return (text || '').replace(/[&<>"']/g, c => map[c] || c);
+    }
+
+    async function loadAudit() {
+      const limit = Math.min(Math.max(parseInt(limitInput.value || '100'), 10), 500);
+      limitInput.value = limit;
+      try {
+        const res = await fetch('/api/audit?limit=' + limit, { headers: headers() });
+        if (!res.ok) {
+          status.textContent = res.status === 401 ? 'Unauthorized: provide a valid token.' : 'Failed to load audit data.';
+          showToast(status.textContent, 'error');
+          return;
+        }
+        const data = await res.json();
+        if (!data.enabled) {
+          status.textContent = 'Audit dashboard is disabled in the config.';
+          stopAutoRefresh();
+          return;
+        }
+        if (data.chatEnabled) panels.chat.innerHTML = renderChat(data.chat || []); else panels.chat.innerHTML = '<p class="muted">Disabled in config.</p>';
+        if (data.blockEnabled) panels.blocks.innerHTML = renderBlocks(data.blocks || []); else panels.blocks.innerHTML = '<p class="muted">Disabled in config.</p>';
+        if (data.containerEnabled) panels.containers.innerHTML = renderContainers(data.containers || []); else panels.containers.innerHTML = '<p class="muted">Disabled in config.</p>';
+        status.textContent = 'Last updated at ' + new Date().toLocaleTimeString();
+      } catch (err) {
+        status.textContent = 'Error: ' + err;
+        showToast('Error while loading audit data', 'error');
+      }
+    }
+
+    function startAutoRefresh() {
+      stopAutoRefresh();
+      refreshHandle = setInterval(loadAudit, 10000);
+    }
+
+    function stopAutoRefresh() {
+      if (refreshHandle) {
+        clearInterval(refreshHandle);
+        refreshHandle = null;
+      }
+    }
+
+    refreshBtn.addEventListener('click', () => {
+      loadAudit();
+    });
+
+    tokenInput.addEventListener('change', () => {
+      const value = (tokenInput.value || '').trim();
+      if (value) localStorage.setItem('glraToken', value); else localStorage.removeItem('glraToken');
+    });
+
+    applySavedToken();
+    loadMeta().then(enabled => {
+      if (enabled) {
+        loadAudit();
+        startAutoRefresh();
+      }
+    });
+  </script>
+</body>
+</html>

--- a/src/main/resources/web/rollback.css
+++ b/src/main/resources/web/rollback.css
@@ -35,6 +35,24 @@ body {
   margin: 0 0 16px;
 }
 
+.header.split {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.action-row {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+}
+
+.action-row button {
+  width: auto;
+}
+
 .card {
   background: rgba(15, 23, 42, 0.7);
   border: 1px solid #1f2937;
@@ -118,6 +136,27 @@ button:active {
   transform: translateY(1px);
 }
 
+.button.secondary,
+.action-row .secondary {
+  background: transparent;
+  color: #cbd5e1;
+  border: 1px solid #334155;
+  width: auto;
+  text-decoration: none;
+  padding: 10px 12px;
+}
+
+.button.secondary:hover,
+.action-row .secondary:hover {
+  background: #0b1220;
+}
+
+.settings-row {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
 .muted {
   color: #94a3b8;
   margin-top: 8px;
@@ -159,6 +198,61 @@ button:active {
   opacity: 1;
   transform: translateY(0);
   pointer-events: auto;
+}
+
+.tabs {
+  display: flex;
+  gap: 8px;
+  margin: 12px 0 8px;
+}
+
+.tab {
+  border: 1px solid #334155;
+  background: rgba(2, 6, 23, 0.5);
+  color: #cbd5e1;
+  padding: 8px 12px;
+  border-radius: 8px;
+  cursor: pointer;
+  width: auto;
+}
+
+.tab.active {
+  border-color: #10b981;
+  color: #10b981;
+  background: rgba(16, 185, 129, 0.1);
+}
+
+.tab:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.tab-panel {
+  display: none;
+  margin-top: 6px;
+}
+
+.tab-panel.active {
+  display: block;
+}
+
+.audit-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.audit-title {
+  color: #cbd5e1;
+  font-weight: 600;
+}
+
+.audit-body {
+  color: #8b949e;
+  font-size: 14px;
 }
 
 /* Responsive tweaks */

--- a/src/main/resources/web/rollback.html
+++ b/src/main/resources/web/rollback.html
@@ -6,11 +6,14 @@
   <link rel="stylesheet" href="/web/rollback.css" />
 </head>
 <body class="page">
-  <div class="container">
-    <div class="header">
-      <h1 id="title">Rollback</h1>
-      <p id="subtitle"></p>
-    </div>
+    <div class="container">
+      <div class="header">
+        <h1 id="title">Rollback</h1>
+        <p id="subtitle"></p>
+        <div class="action-row" id="audit-link-wrapper" style="display:none;">
+          <a id="audit-link" class="button secondary" href="/audit">Open audit</a>
+        </div>
+      </div>
     <div id="toast" class="toast" role="status" aria-live="polite"></div>
     <div class="card">
       <form id="rollback-form" class="form">
@@ -83,6 +86,8 @@
     const playerList = document.getElementById('player-list');
     const dimensionInput = document.getElementById('dimension-input');
     const dimensionList = document.getElementById('dimension-list');
+    const auditLinkWrapper = document.getElementById('audit-link-wrapper');
+    const auditLink = document.getElementById('audit-link');
     const labels = {
       title: document.getElementById('title'),
       subtitle: document.getElementById('subtitle'),
@@ -101,6 +106,62 @@
     };
     let messages = {};
 
+    const initialToken = localStorage.getItem('glraToken') || new URLSearchParams(location.search).get('token');
+    if (initialToken && !document.getElementById('token-input').value) {
+      document.getElementById('token-input').value = initialToken;
+    }
+
+    function getToken() {
+      const current = (document.getElementById('token-input').value || '').trim();
+      if (current) return current;
+      const stored = localStorage.getItem('glraToken');
+      if (stored) return stored;
+      const viaUrl = new URLSearchParams(location.search).get('token');
+      return viaUrl || '';
+    }
+
+    function buildHeaders() {
+      const headers = { 'Accept': 'application/json' };
+      const token = getToken();
+      if (token) headers['X-Auth-Token'] = token;
+      return headers;
+    }
+
+    function persistToken() {
+      const token = document.getElementById('token-input').value.trim();
+      if (token) {
+        localStorage.setItem('glraToken', token);
+      } else {
+        localStorage.removeItem('glraToken');
+      }
+      updateAuditLink();
+    }
+
+    function updateAuditLink() {
+      const token = getToken();
+      if (token) {
+        auditLink.href = '/audit?token=' + encodeURIComponent(token);
+      } else {
+        auditLink.href = '/audit';
+      }
+    }
+
+    document.getElementById('token-input').addEventListener('change', persistToken);
+    updateAuditLink();
+
+    async function loadAuditMeta() {
+      try {
+        const res = await fetch('/api/audit/meta');
+        if (!res.ok) return;
+        const data = await res.json();
+        if (data.enabled) {
+          auditLinkWrapper.style.display = 'flex';
+        }
+      } catch (err) {
+        console.warn('Audit meta fetch failed', err);
+      }
+    }
+
     form.addEventListener('submit', async (e) => {
       e.preventDefault();
       result.textContent = t('sending', 'Sending...');
@@ -116,6 +177,7 @@
         result.style.color = '#ff7b72';
         showToast('Error: ' + err, 'error');
       }
+      persistToken();
     });
 
     function t(key, fallback) {
@@ -158,7 +220,7 @@
 
     async function loadPlayers() {
       try {
-        const res = await fetch('/api/players', { headers: { 'Accept': 'application/json' }});
+        const res = await fetch('/api/players', { headers: buildHeaders() });
         if (!res.ok) return;
         const data = await res.json();
         if (!data.players) return;
@@ -175,7 +237,7 @@
 
     async function loadDimensions() {
       try {
-        const res = await fetch('/api/dimensions', { headers: { 'Accept': 'application/json' }});
+        const res = await fetch('/api/dimensions', { headers: buildHeaders() });
         if (!res.ok) return;
         const data = await res.json();
         if (!data.dimensions) return;
@@ -193,7 +255,7 @@
     async function loadTranslations() {
       try {
         const lang = (navigator.language || 'en').toLowerCase();
-        const res = await fetch('/api/lang?lang=' + encodeURIComponent(lang), { headers: { 'Accept': 'application/json' }});
+        const res = await fetch('/api/lang?lang=' + encodeURIComponent(lang), { headers: buildHeaders() });
         if (!res.ok) return;
         const data = await res.json();
         messages = data.messages || {};
@@ -221,6 +283,7 @@
     loadTranslations();
     loadPlayers();
     loadDimensions();
+    loadAuditMeta();
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add configuration toggles and database DAO for serving audit data
- expose audit endpoints/page with tabbed chat, block, and inventory history that refreshes every 10 seconds
- link the rollback UI to the new audit page and share stored tokens for authenticated access

## Testing
- bash ./gradlew test *(fails: net.neoforged.gradle.userdev plugin not found in configured repositories)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692dd75fa79083259c2dddabb4e08e4f)